### PR TITLE
Set etherpad-lite to look for certs in proper location

### DIFF
--- a/templates/default/etherpad/etherpad-lite.osuosl.org.erb
+++ b/templates/default/etherpad/etherpad-lite.osuosl.org.erb
@@ -39,8 +39,8 @@ server {
   server_name  localhost test-notes.openmrs.org notes.openmrs.org;
 
   ssl on;
-  ssl_certificate /etc/nginx/ssl/new/combined_openmrs.org.crt;
-  ssl_certificate_key /etc/nginx/ssl/new/openmrs.org.key;
+  ssl_certificate /etc/pki/tls/certs/notes-openmrs.pem;
+  ssl_certificate_key /etc/pki/tls/private/notes-openmrs.key;
 
   ssl_session_timeout  5m;
 


### PR DESCRIPTION
To follow up on: 
https://github.com/osuosl-cookbooks/proj-misc/commit/320fdbee397c27e584f38e12682751d28e0dc537