### PR TITLE
Switch to chef_nginx

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,7 @@ source 'https://supermarket.chef.io'
 
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
+cookbook 'munin', git: 'git@github.com:osuosl-cookbooks/munin.git'
 cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
 cookbook 'osl-nginx-test', path: 'test/cookbooks/osl-nginx-test'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version          '1.1.4'
 depends          'certificate'
 depends          'firewall'
 depends          'logrotate'
-depends          'nginx'
+depends          'chef_nginx', '~> 2.9.0'
 depends          'osl-munin'
 depends          'osl-nrpe'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,5 +19,5 @@
 include_recipe 'firewall::http'
 
 node['osl-nginx']['recipes'].each do |recipe|
-  include_recipe "nginx::#{recipe}"
+  include_recipe "chef_nginx::#{recipe}"
 end

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 include_recipe 'osl-nrpe::check_http'
-include_recipe 'nginx::http_stub_status_module'
+include_recipe 'chef_nginx::http_stub_status_module'
 include_recipe 'osl-munin::client'
 
 template ::File.join(node['munin']['basedir'], 'plugin-conf.d/nginx') do


### PR DESCRIPTION
Chef has forked the nginx cookbook and resolved many of the annoying dependency
issues. This resolves many of our odd cookbook dependency problems we have.