### PR TITLE
User newer chef_nginx cookbook 6.2.0

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,7 @@
 source 'https://supermarket.chef.io'
 
+solver :ruby, :required
+
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-munin', git: 'git@github.com:osuosl-cookbooks/osl-munin'
 cookbook 'munin', git: 'git@github.com:osuosl-cookbooks/munin.git'

--- a/definitions/nginx_app.rb
+++ b/definitions/nginx_app.rb
@@ -100,6 +100,10 @@ define :nginx_app,
     end
   end
   nginx_site "#{params[:name]}.conf" do
-    enable params[:enable]
+    if params[:enable]
+      action :enable
+    else
+      action :disable
+    end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '2.1.1'
 depends          'certificate'
 depends          'firewall'
 depends          'logrotate'
-depends          'chef_nginx', '~> 2.9.0'
+depends          'chef_nginx', '~> 6.2.0'
 depends          'osl-munin'
 depends          'osl-nrpe'
 

--- a/recipes/project_etherpad_lite.rb
+++ b/recipes/project_etherpad_lite.rb
@@ -25,7 +25,7 @@ end
 
 nginx_app 'etherpad-lite.osuosl.org-back' do
   template 'etherpad/etherpad-lite.osuosl.org-back.erb'
-  enable false
+  action :disable
 end
 
 nginx_app 'nginx_status' do


### PR DESCRIPTION
This is required so that we can use a newer ohai which we need in other
cookbooks.