### PR TITLE
Update to use nginx 11.4 cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '4.3.0'
 depends          'certificate'
 depends          'firewall'
 depends          'logrotate'
-depends          'nginx', '~> 10.3.2'
+depends          'nginx', '~> 11.4.0'
 depends          'osl-nrpe'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,9 +18,25 @@
 #
 include_recipe 'firewall::http'
 
-nginx_install 'repo'
+nginx_install 'osuosl' do
+  source 'repo'
+end
 
-# make this availible for notify statements
-service 'nginx' do
-  action :nothing
+nginx_config 'osuosl' do
+  notifies :restart, 'nginx_service[osuosl]', :delayed
+end
+
+nginx_service 'osuosl' do
+  action :enable
+  delayed_action :start
+end
+
+directory "#{nginx_dir}/includes.d"
+
+# TODO(ramereth): Remove after this has been deployed
+%w(sites-available sites-enabled).each do |d|
+  directory "#{nginx_dir}/#{d}" do
+    recursive true
+    action :delete
+  end
 end

--- a/resources/nginx_app.rb
+++ b/resources/nginx_app.rb
@@ -39,7 +39,7 @@ action :create do
   end
 
   if new_resource.include_config
-    vhost_include = ::File.join(nginx_dir, 'sites-available', "#{new_resource.include_name}_include.conf")
+    vhost_include = ::File.join(nginx_dir, 'includes.d', "#{new_resource.include_name}_include.conf")
 
     case new_resource.include_resource
     when 'cookbook_file'
@@ -50,8 +50,8 @@ action :create do
         group nginx_user
         mode '0644'
 
-        if ::File.exist?(::File.join(nginx_dir, 'sites-enabled', "#{new_resource.include_name}.conf"))
-          notifies :reload, 'service[nginx]'
+        if ::File.exist?(::File.join(nginx_dir, 'includes.d', "#{new_resource.include_name}.conf"))
+          notifies :reload, 'nginx_service[osuosl]'
         end
       end
 
@@ -63,8 +63,8 @@ action :create do
         group nginx_user
         mode '0644'
 
-        if ::File.exist?(::File.join(nginx_dir, 'sites-enabled', "#{new_resource.include_name}.conf"))
-          notifies :reload, 'service[nginx]'
+        if ::File.exist?(::File.join(nginx_dir, 'includes.d', "#{new_resource.include_name}.conf"))
+          notifies :reload, 'nginx_service[osuosl]'
         end
       end
     else
@@ -72,30 +72,15 @@ action :create do
     end
   end
 
-  declare_resource(:template, "#{nginx_dir}/sites-available/#{new_resource.name}.conf") do
-    source new_resource.template
+  nginx_site new_resource.name do
     cookbook new_resource.cookbook
-    owner nginx_user
-    group nginx_user
-    mode '0644'
+    template new_resource.template
     variables(
       server_aliases: new_resource.server_aliases,
       nginx_log_dir: nginx_log_dir,
       nginx_dir: nginx_dir,
       params: all_params
     )
-
-    if ::File.exist?(::File.join(nginx_dir, 'sites-enabled', "#{new_resource.name}.conf"))
-      notifies :reload, 'service[nginx]'
-    end
-  end
-
-  nginx_site "#{new_resource.name}.conf" do
-    if new_resource.enable
-      action :enable
-    else
-      action :disable
-    end
   end
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -11,13 +11,24 @@ describe 'osl-nginx::default' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to install_nginx_install('repo')
+        expect(chef_run).to install_nginx_install('osuosl').with(source: 'repo')
       end
       it do
-        expect(chef_run).to nothing_service('nginx')
+        expect(chef_run).to create_nginx_config('osuosl')
       end
       it do
-        expect(chef_run).to nothing_service('nginx')
+        expect(chef_run).to enable_nginx_service('osuosl')
+      end
+      it do
+        expect(chef_run).to start_nginx_service('osuosl')
+      end
+      it do
+        expect(chef_run).to create_directory('/etc/nginx/includes.d')
+      end
+      %w(sites-available sites-enabled).each do |d|
+        it do
+          expect(chef_run).to delete_directory("/etc/nginx/#{d}").with(recursive: true)
+        end
       end
     end
   end

--- a/templates/default/nginx_app.conf.erb
+++ b/templates/default/nginx_app.conf.erb
@@ -12,7 +12,7 @@ server {
   <% end %>
   <% if @params[:include_config] then  %>
 
-  include <%= "#{@nginx_dir}/sites-available/#{@params[:include_name] || @params[:name]}_include.conf" %>;
+  include <%= "#{@nginx_dir}/includes.d/#{@params[:include_name] || @params[:name]}_include.conf" %>;
   <% end %>
   <% if @params[:directive_http] %>
 
@@ -42,7 +42,7 @@ server {
   ssl_certificate_key <%= @params[:cert_key] %>;
   <% if @params[:include_config] then  %>
 
-  include <%= "#{@nginx_dir}/sites-available/#{@params[:include_name] || @params[:name]}_include.conf" %>;
+  include <%= "#{@nginx_dir}/includes.d/#{@params[:include_name] || @params[:name]}_include.conf" %>;
   <% end %>
   <% if @params[:directive_https] %>
 

--- a/test/integration/cookbook-test/inspec/cookbook_test_spec.rb
+++ b/test/integration/cookbook-test/inspec/cookbook_test_spec.rb
@@ -18,90 +18,86 @@ describe port(443) do
   it { should_not be_listening }
 end
 
-conf_dir = '/etc/nginx/sites-available'
+conf_dir = '/etc/nginx/conf.http.d'
+include_dir = '/etc/nginx/includes.d'
 
 describe file(::File.join(conf_dir, 'test-cookbook.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should_not match /ssl_certificate/ }
-  its('content') { should match %r{include /etc/nginx/sites-available/test-cookbook\.osuosl\.org_include\.conf;} }
+  its('content') { should match %r{include /etc/nginx/includes.d/test-cookbook\.osuosl\.org_include\.conf;} }
 end
 
 describe file(::File.join(conf_dir, 'test-cookbook-name.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
-  its('content') { should match %r{include /etc/nginx/sites-available/test-cookbook_include\.conf;} }
+  its('content') { should match %r{include /etc/nginx/includes.d/test-cookbook_include\.conf;} }
   its('content') { should match /server_name test-cookbook-name\.osuosl\.org;$/ }
 end
 
 describe file(::File.join(conf_dir, 'test-cookbook-include.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
-  its('content') { should match %r{include /etc/nginx/sites-available/test_include\.conf;} }
+  its('content') { should match %r{include /etc/nginx/includes.d/test_include\.conf;} }
   its('content') { should match /server_name test-cookbook-include\.osuosl\.org;$/ }
 end
 
 describe file(::File.join(conf_dir, 'test-cookbook-template.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /cookbook-template$/ }
 end
 
 describe file(::File.join(conf_dir, 'test-cookbook-include-template.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
-  its('content') { should match %r{include /etc/nginx/sites-available/test-include_include\.conf;} }
+  its('content') { should match %r{include /etc/nginx/includes.d/test-include_include\.conf;} }
   its('content') { should match /server_name test-cookbook-include-template\.osuosl\.org;$/ }
 end
 
-describe file(::File.join(conf_dir, 'test_include.conf')) do
+describe file(::File.join(include_dir, 'test_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /test-include-name/ }
 end
 
-describe file(::File.join(conf_dir, 'test-cookbook_include.conf')) do
+describe file(::File.join(include_dir, 'test-cookbook_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /test-name-cookbook/ }
 end
 
-describe file(::File.join(conf_dir, 'test-cookbook.osuosl.org_include.conf')) do
+describe file(::File.join(include_dir, 'test-cookbook.osuosl.org_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /test-cookbook/ }
 end
 
-describe file(::File.join(conf_dir, 'test_include.conf')) do
+describe file(::File.join(include_dir, 'test_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /test-include-name/ }
 end
 
-describe file(::File.join(conf_dir, 'test-include_include.conf')) do
+describe file(::File.join(include_dir, 'test-include_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /cookbook-include-template/ }
 end
 
-%w(
-  test-cookbook
-  test-cookbook-include
-  test-cookbook-include
-  test-cookbook-template
-  test-cookbook-include-template
-).each do |f|
-  describe file("/etc/nginx/sites-enabled/#{f}.osuosl.org.conf") do
-    it { should be_linked_to "/etc/nginx/sites-available/#{f}.osuosl.org.conf" }
+describe file '/etc/nginx/conf.http.d/list.conf' do
+  %w(
+    test-cookbook
+    test-cookbook-include
+    test-cookbook-include
+    test-cookbook-template
+    test-cookbook-include-template
+  ).each do |f|
+    its('content') { should match %r{^include /etc/nginx/conf.http.d/#{f}.osuosl.org.conf;$} }
   end
 end

--- a/test/integration/vhost/inspec/vhost_spec.rb
+++ b/test/integration/vhost/inspec/vhost_spec.rb
@@ -16,10 +16,10 @@ end
   end
 end
 
-conf_dir = '/etc/nginx/sites-available'
+conf_dir = '/etc/nginx/conf.http.d'
+include_dir = '/etc/nginx/includes.d'
 
 describe file(::File.join(conf_dir, 'test.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') do
@@ -34,45 +34,43 @@ describe file(::File.join(conf_dir, 'test.osuosl.org.conf')) do
 end
 
 describe file(::File.join(conf_dir, 'test-include.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') do
-    should match %r{include /etc/nginx/sites-available/test-include\.osuosl\.org_include\.conf;}
+    should match %r{include /etc/nginx/includes.d/test-include\.osuosl\.org_include\.conf;}
   end
   its('content') { should match /server_name test-include\.osuosl\.org;$/ }
 end
 
 describe file(::File.join(conf_dir, 'test-include-name.osuosl.org.conf')) do
-  its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') do
-    should match %r{include /etc/nginx/sites-available/test_include\.conf;}
+    should match %r{include /etc/nginx/includes.d/test_include\.conf;}
   end
   its('content') { should match /server_name test-include-name\.osuosl\.org;$/ }
 end
 
-describe file(::File.join(conf_dir, 'test_include.conf')) do
+describe file(::File.join(include_dir, 'test_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /test-include-name/ }
 end
 
-describe file(::File.join(conf_dir, 'test-include.osuosl.org_include.conf')) do
+describe file(::File.join(include_dir, 'test-include.osuosl.org_include.conf')) do
   its('mode') { should cmp '0644' }
   its('owner') { should cmp 'nginx' }
   its('group') { should cmp 'nginx' }
   its('content') { should match /test-include-hostname/ }
 end
 
-%w(
-  test
-  test-include
-  test-include-name
-).each do |f|
-  describe file("/etc/nginx/sites-enabled/#{f}.osuosl.org.conf") do
-    it { should be_linked_to "/etc/nginx/sites-available/#{f}.osuosl.org.conf" }
+describe file '/etc/nginx/conf.http.d/list.conf' do
+  %w(
+    test
+    test-include
+    test-include-name
+  ).each do |f|
+    its('content') { should match %r{^include /etc/nginx/conf.http.d/#{f}.osuosl.org.conf;$} }
   end
 end


### PR DESCRIPTION
NOTE: This is needed to use the newer nagios cookbook.

This makes a few adjustments to make this work with the changes that were implemented in version 11.x of this cookbook. This moved away from using "sites-enabled" to using a different method for virtual sites.

- Use `/etc/nginx/includes.d` for our included config files since sites-available is no longer available
- Don't directly manage the vhost template anymore and just use `nginx_site` directly instead.
- Update tests for using the newer configuration style
- Remove old sites-available sites-enabled directories
