### PR TITLE
Set unified_mode for custom resources

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,6 @@ source 'https://supermarket.chef.io'
 
 solver :ruby, :required
 
-cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
 cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
 cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ description      'Installs/Configures osl-nginx'
 version          '6.0.0'
 
 depends          'certificate'
-depends          'logrotate'
+depends          'logrotate', '~> 2.3.0'
 depends          'nginx', '~> 11.4.0'
 depends          'osl-firewall'
 depends          'osl-nrpe'

--- a/resources/nginx_app.rb
+++ b/resources/nginx_app.rb
@@ -1,5 +1,6 @@
 resource_name :nginx_app
 provides :nginx_app
+unified_mode true
 
 default_action :create
 


### PR DESCRIPTION
The latest version of `logrotate` removed all recipes, but is required for `unified_mode` in its resources. I pinned this cookbook to the older version for now, but we'll need to update at some point.

