### PR TITLE
Update logrotate to 3.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ description      'Installs/Configures osl-nginx'
 version          '6.2.0'
 
 depends          'certificate'
-depends          'logrotate', '~> 2.2.0'
+depends          'logrotate', '~> 3.0.0'
 depends          'nginx', '~> 12.0.0'
 depends          'osl-firewall'
 depends          'osl-nrpe'

--- a/recipes/logrotate.rb
+++ b/recipes/logrotate.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'logrotate'
+logrotate_package 'osl-nginx'
 
 Chef::DSL::Universal.include(Nginx::Cookbook::Helpers)
 

--- a/spec/unit/recipes/logrotate_spec.rb
+++ b/spec/unit/recipes/logrotate_spec.rb
@@ -14,8 +14,12 @@ describe 'osl-nginx::logrotate' do
       end
 
       it do
+        expect(chef_run).to upgrade_logrotate_package('osl-nginx')
+      end
+
+      it do
         expect(chef_run).to enable_logrotate_app('nginx').with(
-          path: '/var/log/nginx/*/*/*.log',
+          path: '"/var/log/nginx/*/*/*.log"',
           frequency: 'daily',
           postrotate: '[ ! -f /run/nginx.pid ] || kill -USR1 `cat /run/nginx.pid`'
         )


### PR DESCRIPTION
Must release along side other `logrotate` updates. Had to change the spec test because of `logrotate` cookbook internals