### PR TITLE
AlmaLinux 10 support

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,12 +1,7 @@
 source 'https://supermarket.chef.io'
+source 'https://supermarket.osuosl.org'
 
 solver :ruby, :required
-
-cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
-cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
-cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
-cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
-cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 
 # test dependencies
 cookbook 'osl-nginx-test', path: 'test/cookbooks/osl-nginx-test'

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -21,3 +21,11 @@ platforms:
     driver:
       image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: almalinux-10
+    driver:
+      image: dokken/almalinux-10
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -25,3 +25,15 @@ platforms:
       image_ref: "AlmaLinux 8"
     transport:
       username: almalinux
+  - name: almalinux-9
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 9"
+    transport:
+      username: almalinux
+  - name: almalinux-10
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 10"
+    transport:
+      username: almalinux

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,7 +13,7 @@ transport:
 provisioner:
   name: chef_infra
   product_name: cinc
-  product_version: '17'
+  product_version: '18'
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -27,6 +27,8 @@ provisioner:
 
 platforms:
   - name: almalinux-8
+  - name: almalinux-9
+  - name: almalinux-10
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,3 +17,4 @@ depends          'osl-selinux'
 
 supports         'almalinux', '~> 8.0'
 supports         'almalinux', '~> 9.0'
+supports         'almalinux', '~> 10.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-nginx
 # Recipe:: default
 #
-# Copyright:: 2014-2024, Oregon State University
+# Copyright:: 2014-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mon.rb
+++ b/recipes/mon.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-nginx
 # Recipe:: mon
 #
-# Copyright:: 2014-2024, Oregon State University
+# Copyright:: 2014-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,9 +11,15 @@ ALMA_9 = {
   version: '9',
 }.freeze
 
+ALMA_10 = {
+  platform: 'almalinux',
+  version: '10',
+}.freeze
+
 ALL_PLATFORMS = [
   ALMA_8,
   ALMA_9,
+  ALMA_10,
 ].freeze
 
 RSpec.configure do |config|


### PR DESCRIPTION
When I run rake or rspec, I get this in the output but the tests still pass.
`Fetched 'almalinux/10' from GitHub, but could not write to the local path: /opt/cinc-workstation/embedded/lib/ruby/gems/3.1.0/gems/fauxhai-chef-9.3.26/lib/fauxhai/platforms/almalinux/10.json. Fix the local file permissions to avoid downloading this file every run.`
